### PR TITLE
Changed gradle to use implementation

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -16,7 +16,7 @@ android {
 }
 
 dependencies {
-  compile 'com.android.support:appcompat-v7:26.1.0'
+  implementation 'com.android.support:appcompat-v7:26.1.0'
 }
 
 apply plugin: 'com.getkeepsafe.dexcount'


### PR DESCRIPTION
Updated the gradle file to use implementation rather than compile.
I'm doing that because Android won't support compile at the end of 2018.