### PR TITLE
Bugfix: onSetInitialValue should not overwrite current setting

### DIFF
--- a/library/src/main/java/com/jaredrummler/android/colorpicker/ColorPreferenceCompat.java
+++ b/library/src/main/java/com/jaredrummler/android/colorpicker/ColorPreferenceCompat.java
@@ -131,8 +131,7 @@ public class ColorPreferenceCompat extends Preference implements ColorPickerDial
   @Override protected void onSetInitialValue(Object defaultValue) {
     super.onSetInitialValue(defaultValue);
     if (defaultValue instanceof Integer) {
-      color = (Integer) defaultValue;
-      persistInt(color);
+      color = getPersistedInt((Integer) defaultValue);
     } else {
       color = getPersistedInt(0xFF000000);
     }


### PR DESCRIPTION
When using custom data storage for preferences, ColorPicker overwrites current value with default value. This fixes issue.